### PR TITLE
FIX: Actually close on stop

### DIFF
--- a/suitcase/jsonl/__init__.py
+++ b/suitcase/jsonl/__init__.py
@@ -186,10 +186,9 @@ class Serializer(event_model.DocumentRouter):
         self._output_file.write(line)
         if self._flush:
             self._output_file.flush()
+        if name == 'stop':
+            self.close()
         return name, doc
-
-    def stop(self, doc):
-        self.close()
 
     def close(self):
         self._manager.close()


### PR DESCRIPTION
The `stop(doc)` method was never being called because
`DocumentRouter.__call__` is being refined in the subclass without
calling `super()`.

We could potentially fix this was calling `super()` but in one case
('start') we want the subclass to go *first* (open the file) and in
another case ('stop') we want the subclass to go *second* (close the
file). Just using `if` blocks consistently for both seems simplest.