### PR TITLE
FIX: make Serializer.stop idempotent

### DIFF
--- a/suitcase/jsonl/__init__.py
+++ b/suitcase/jsonl/__init__.py
@@ -157,6 +157,8 @@ class Serializer(event_model.DocumentRouter):
         else:
             self._manager = directory
 
+        self._closed = False
+
     @property
     def artifacts(self):
         # The manager's artifacts attribute is itself a property, and we must
@@ -191,7 +193,9 @@ class Serializer(event_model.DocumentRouter):
         return name, doc
 
     def close(self):
-        self._manager.close()
+        if not self._closed:
+            self._closed = True
+            self._manager.close()
 
     def __enter__(self):
         return self

--- a/suitcase/jsonl/tests/tests.py
+++ b/suitcase/jsonl/tests/tests.py
@@ -1,6 +1,6 @@
 import json
 from event_model import NumpyEncoder
-from suitcase.jsonl import export
+from suitcase.jsonl import export, Serializer
 
 
 def test_export(tmp_path, example_data):
@@ -35,3 +35,12 @@ def test_file_prefix_formatting(file_prefix_list, example_data, tmp_path):
         unique_actual = set(str(artifact).split('/')[-1].partition('-')[0]
                             for artifact in artifacts['all'])
         assert unique_actual == set([templated_file_prefix])
+
+
+def test_double_close(example_data, tmp_path):
+    collector = example_data()
+    with Serializer(tmp_path) as sc:
+        for name, doc in collector:
+            sc(name, doc)
+        sc.close()
+        sc.close()


### PR DESCRIPTION
The Serializer will close itself on stop, but this behavior is not consistent
across all Serializer (and we may not see a stop!) so make it safe to call
`ser.close()` repeatedly.

This will un-break part of the databroker v2 fixtures.